### PR TITLE
🩹 SEO fixes

### DIFF
--- a/src/app/explorer/[chainId]/layout.tsx
+++ b/src/app/explorer/[chainId]/layout.tsx
@@ -8,6 +8,8 @@ import { Flex, ScrollArea } from "@radix-ui/themes";
 import Navbar from "@/components/navbar";
 import Sidebar from "@/components/sidebar";
 import { EntitiesProvider } from "@/providers/entities";
+import type { Metadata } from 'next'
+import { title, description } from "@/config/site";
 
 type Props = {
   children: ReactNode;
@@ -15,6 +17,15 @@ type Props = {
     chainId: SupportedChainId;
   };
 };
+ 
+export async function generateMetadata(
+  { params }: Props
+): Promise<Metadata> {
+  return {
+    title: title + ' for ' + params.chainId,
+    description: description.slice(0,-1) + ' for ' + params.chainId + '.',
+  }
+}
 
 const ExplorerLayout: FC<Props> = ({ children, params: { chainId } }) => {
   return (

--- a/src/app/explorer/[chainId]/page.tsx
+++ b/src/app/explorer/[chainId]/page.tsx
@@ -35,7 +35,7 @@ const Explorer: FC<Props> = () => {
   if (entities.length === 0) {
     return (
       <Flex width="100%" direction="column" justify="center" align="center">
-        <Heading size="3" className="text-center">
+        <Heading as="h1" size="3" className="text-center">
           Not sure where to start? 👇
         </Heading>
         <Button

--- a/src/components/entities/access-managed/index.tsx
+++ b/src/components/entities/access-managed/index.tsx
@@ -84,7 +84,7 @@ const AccessManaged: FC<Props> = ({
         ) : accessManaged ? (
           <Flex direction="column">
             <Flex align="center" width="100%" justify="between">
-              <Heading size="2">Authority</Heading>
+              <Heading as="h2" size="2">Authority</Heading>
               <Address
                 addreth={{
                   shortenAddress: 10,
@@ -101,7 +101,7 @@ const AccessManaged: FC<Props> = ({
             </Flex>
             <Separator size="4" my="3" />
             {(accessManaged?.asAccount.targettedBy?.length ?? 0) > 0 && (
-              <Heading size="2">Targetted by:</Heading>
+              <Heading as="h2" size="2">Targetted by:</Heading>
             )}
             {accessManaged?.asAccount.targettedBy.map((target) => (
               <Card key={target.id} my="2" size="1">

--- a/src/components/entities/access-manager-role-member/index.tsx
+++ b/src/components/entities/access-manager-role-member/index.tsx
@@ -110,7 +110,7 @@ const AccessManagerMember: FC<Props> = ({
       ) : accessManagerRoleMember ? (
         <Flex direction="column">
           <Flex align="center" width="100%" justify="between">
-            <Heading size="2">Manager</Heading>
+            <Heading as="h2" size="2">Manager</Heading>
             <Address
               addreth={{
                 shortenAddress: 10,
@@ -127,7 +127,7 @@ const AccessManagerMember: FC<Props> = ({
           </Flex>
           <Separator size="4" my="3" />
           <Flex align="center" width="100%" justify="between">
-            <Heading size="2">Role</Heading>
+            <Heading as="h2" size="2">Role</Heading>
             {accessManagerRoleMember?.role && (
               <Role
                 size="2"
@@ -138,7 +138,7 @@ const AccessManagerMember: FC<Props> = ({
           </Flex>
           <Separator size="4" my="3" />
           <Flex align="center" width="100%" justify="between">
-            <Heading size="2">
+            <Heading as="h2" size="2">
               Execution delay
               <Info ml="3" mt="1">
                 <Text size="1">
@@ -158,7 +158,7 @@ const AccessManagerMember: FC<Props> = ({
           </Flex>
           <Separator size="4" my="3" />
           <Flex align="center" width="100%" justify="between">
-            <Heading size="2">Member since</Heading>
+            <Heading as="h2" size="2">Member since</Heading>
             <Flex align="center">
               <Text size="2">
                 {format.relativeTime(

--- a/src/components/entities/access-manager-role/index.tsx
+++ b/src/components/entities/access-manager-role/index.tsx
@@ -110,7 +110,7 @@ const AccessManagerRole: FC<Props> = ({
         ) : accessManagerRole ? (
           <Flex direction="column">
             <Flex align="center" width="100%" justify="between">
-              <Heading size="2">Manager</Heading>
+              <Heading as="h2" size="2">Manager</Heading>
               <Address
                 addreth={{
                   address: accessManagerRole?.manager.asAccount.id,
@@ -127,7 +127,7 @@ const AccessManagerRole: FC<Props> = ({
             </Flex>
             <Separator size="4" my="3" />
             <Flex align="center" width="100%" justify="between">
-              <Heading size="2">
+              <Heading as="h2" size="2">
                 Grant delay
                 <Info ml="3" mt="1">
                   <Text size="1">
@@ -144,7 +144,7 @@ const AccessManagerRole: FC<Props> = ({
             </Flex>
             <Separator size="4" my="3" />
             <Flex align="center" width="100%" justify="between">
-              <Heading size="2">
+              <Heading as="h2" size="2">
                 Admin
                 <Info ml="3" mt="1">
                   <Text size="1">
@@ -168,7 +168,7 @@ const AccessManagerRole: FC<Props> = ({
             </Flex>
             <Separator size="4" my="3" />
             <Flex align="center" width="100%" justify="between">
-              <Heading size="2">
+              <Heading as="h2" size="2">
                 Guardian
                 <Info ml="3" mt="1">
                   <Text size="1">
@@ -192,7 +192,7 @@ const AccessManagerRole: FC<Props> = ({
             <Separator size="4" my="3" />
             {(accessManagerRole?.adminOf.length ?? 0) > 0 && (
               <Flex direction="column">
-                <Heading size="3" mt="4" mb="2">
+                <Heading as="h2" size="3" mt="4" mb="2">
                   Admin of
                 </Heading>
                 <Grid columns="2" gap="3" width="auto">
@@ -213,7 +213,7 @@ const AccessManagerRole: FC<Props> = ({
             )}
             {(accessManagerRole?.guardianOf.length ?? 0) > 0 && (
               <Flex direction="column">
-                <Heading size="3" mt="4" mb="2">
+                <Heading as="h2" size="3" mt="4" mb="2">
                   Guardian of
                 </Heading>
                 <Grid columns="2" gap="3" width="auto">
@@ -232,7 +232,7 @@ const AccessManagerRole: FC<Props> = ({
                 </Grid>
               </Flex>
             )}
-            <Heading size="3" mt="4" mb="2">
+            <Heading as="h2" size="3" mt="4" mb="2">
               Members
             </Heading>
             {(accessManagerRole?.members.length ?? 0) > 0 ? (
@@ -265,7 +265,7 @@ const AccessManagerRole: FC<Props> = ({
                 <Callout.Text>No members</Callout.Text>
               </Callout.Root>
             )}
-            <Heading size="3" mt="4" mb="2">
+            <Heading as="h2" size="3" mt="4" mb="2">
               Functions
             </Heading>
             {(accessManagerRole?.functions.length ?? 0) > 0 ? (

--- a/src/components/entities/access-manager-target-function/index.tsx
+++ b/src/components/entities/access-manager-target-function/index.tsx
@@ -112,7 +112,7 @@ const AccessManagerTargetFunction: FC<Props> = ({
         ) : accessManagedTargetFunction ? (
           <Flex direction="column">
             <Flex align="center" width="100%" justify="between">
-              <Heading size="2">Manager</Heading>
+              <Heading as="h2" size="2">Manager</Heading>
               {accessManagedTargetFunction?.manager.asAccount.id && (
                 <Address
                   addreth={{
@@ -131,7 +131,7 @@ const AccessManagerTargetFunction: FC<Props> = ({
             </Flex>
             <Separator size="4" my="3" />
             <Flex align="center" width="100%" justify="between">
-              <Heading size="2">Target</Heading>
+              <Heading as="h2" size="2">Target</Heading>
               {accessManagedTargetFunction?.target.asAccount.id && (
                 <Address
                   addreth={{
@@ -150,7 +150,7 @@ const AccessManagerTargetFunction: FC<Props> = ({
             </Flex>
             <Separator size="4" my="3" />
             <Flex align="center" width="100%" justify="between">
-              <Heading size="2">
+              <Heading as="h2" size="2">
                 Allowed role
                 <Info ml="3" mt="1">
                   <Text size="1">

--- a/src/components/entities/access-manager-target/index.tsx
+++ b/src/components/entities/access-manager-target/index.tsx
@@ -115,7 +115,7 @@ const AccessManagerTarget: FC<Props> = ({
         ) : accessManagerTarget ? (
           <Flex direction="column">
             <Flex align="center" width="100%" justify="between">
-              <Heading size="2">Targetted by</Heading>
+              <Heading as="h2" size="2">Targetted by</Heading>
               {accessManagerTarget?.manager.asAccount.id && (
                 <Address
                   addreth={{
@@ -134,7 +134,7 @@ const AccessManagerTarget: FC<Props> = ({
             </Flex>
             <Separator size="4" my="3" />
             <Flex align="center" width="100%" justify="between">
-              <Heading size="2">
+              <Heading as="h2" size="2">
                 Admin delay
                 <Info ml="3" mt="1">
                   <Text size="1">
@@ -156,7 +156,7 @@ const AccessManagerTarget: FC<Props> = ({
             <Separator size="4" my="3" />
             <Flex align="center" width="100%" justify="between">
               <Flex>
-                <Heading size="2">Status</Heading>
+                <Heading as="h2" size="2">Status</Heading>
                 <Info ml="3" mt="1">
                   <Text size="1">
                     A target can be closed, which means that every{" "}
@@ -191,7 +191,7 @@ const AccessManagerTarget: FC<Props> = ({
                 See as AccessManaged <ArrowRightIcon />
               </Button>
             )}
-            <Heading size="3" mt="4" mb="2">
+            <Heading as="h2" size="3" mt="4" mb="2">
               Managed functions
             </Heading>
             {(accessManagerTarget?.functions.length ?? 0) > 0 ? (

--- a/src/components/sidebar/content/favorites-section/index.tsx
+++ b/src/components/sidebar/content/favorites-section/index.tsx
@@ -27,7 +27,7 @@ const FavoritesSection = <T extends Kind>({
       <Flex align="center" mb="1" mt="4">
         <Collapsible.Trigger>
           <Flex width="100%">
-            <Heading size="2" mr="2" weight="light">
+            <Heading as="h2" size="2" mr="2" weight="light">
               {name}
             </Heading>
             {!open ? (

--- a/src/components/sidebar/content/index.tsx
+++ b/src/components/sidebar/content/index.tsx
@@ -150,7 +150,7 @@ const Content: FC<Props> = ({ onNavigate = () => {} }) => {
               color="gray"
               onClick={openConnectModal}
             >
-              <Heading size="2" mr="2">
+              <Heading as="h2" size="2" mr="2">
                 Add wallet
               </Heading>
               <PlusIcon width="16" height="16" />
@@ -167,7 +167,7 @@ const Content: FC<Props> = ({ onNavigate = () => {} }) => {
               </Text>
             </Flex>
           ) : (
-            <Heading size="1" ml="4" mb="1">
+            <Heading as="h2" size="1" ml="4" mb="1">
               Member of
             </Heading>
           )}
@@ -181,7 +181,7 @@ const Content: FC<Props> = ({ onNavigate = () => {} }) => {
         </Collapsible.Content>
       </Collapsible.Root>
       <Separator my="3" size="4" />
-      {!isEmpty && <Heading size="1">Favorites</Heading>}
+      {!isEmpty && <Heading as="h2" size="1">Favorites</Heading>}
       {accessManagerFavorites.length > 0 && (
         <FavoritesSection
           name="Access Managers"


### PR DESCRIPTION
Simple fixes for duplicate `h1`, `title`, and `description`.